### PR TITLE
Add network monitoring attack scenarios

### DIFF
--- a/defensive-security/network-monitoring/README.md
+++ b/defensive-security/network-monitoring/README.md
@@ -36,42 +36,5 @@ This project, located under [`defensive-security/network-monitoring`](https://gi
 ```wireshark
 ip.addr == 192.168.1.5 && tcp.flags.syn == 1
 http.request && ip.dst == 10.0.0.2
-tcp.port == 22 && tcp.analysis.retransmission# 🛡️ Blue Team Exercise: Network Threat Detection with Wireshark
-
-This repository demonstrates how to detect common network threats using Wireshark. The lab simulates several attack types and shows how to capture, analyze, and detect them using open-source tools.
-
-## 🔧 Lab Setup
-
-- **Attacker**: Kali Linux
-- **Victim**: Ubuntu or Windows VM
-- **Sniffer**: Wireshark or tcpdump on the same or a mirrored interface
-- **Tools Used**: Nmap, Hydra, Wireshark, Suricata (optional)
-
-## 📦 Scenarios Included
-
-| Scenario | Description | Link |
-|---------|-------------|------|
-| Nmap Scan | Simulates active reconnaissance | [nmap-scan.md](attack-scenarios/nmap-scan.md) |
-| Brute Force | Simulates SSH brute force login attempt | [brute-force.md](attack-scenarios/brute-force.md) |
-| Malware Beaconing | Simulates periodic communication to an external server | [beaconing.md](attack-scenarios/beaconing.md) |
-
-## 📁 Files
-
-- `pcaps/`: Packet captures of each attack.
-- `filters/`: Wireshark filters used for detection.
-- `screenshots/`: Analysis visuals and explanations.
-- `rules/`: Optional Suricata rule examples.
-
-## 🧪 How to Use
-
-1. Open `.pcapng` files in Wireshark.
-2. Apply corresponding filter from `filters/`.
-3. Compare traffic patterns and match against known indicators.
-4. Review screenshots and notes for threat indicators.
-
-## ✅ Example Filters
-
-```wireshark
-ip.addr == 192.168.1.5 && tcp.flags.syn == 1
-http.request && ip.dst == 10.0.0.2
 tcp.port == 22 && tcp.analysis.retransmission
+```

--- a/defensive-security/network-monitoring/attack-scenarios/beaconing.md
+++ b/defensive-security/network-monitoring/attack-scenarios/beaconing.md
@@ -1,0 +1,8 @@
+# Malware Beaconing
+
+This scenario shows periodic outbound connections made by malware to a command-and-control server. The traffic is captured to analyze beaconing behavior.
+
+## Steps
+1. Simulate beaconing with a script that makes scheduled HTTP requests to an external server.
+2. Capture the traffic with Wireshark.
+3. Observe the regular intervals of outbound connections.

--- a/defensive-security/network-monitoring/attack-scenarios/brute-force.md
+++ b/defensive-security/network-monitoring/attack-scenarios/brute-force.md
@@ -1,0 +1,8 @@
+# Brute Force
+
+This scenario simulates an SSH brute force attack. Multiple login attempts are generated to a target host, which should be visible in the packet capture.
+
+## Steps
+1. Use a tool such as Hydra to perform the attack: `hydra -l user -P passwords.txt ssh://<target>`.
+2. Capture the traffic with Wireshark.
+3. Identify repeated failed SSH login attempts in the capture.

--- a/defensive-security/network-monitoring/attack-scenarios/nmap-scan.md
+++ b/defensive-security/network-monitoring/attack-scenarios/nmap-scan.md
@@ -1,0 +1,8 @@
+# Nmap Scan
+
+This scenario demonstrates how an attacker performs network reconnaissance using Nmap. Capture the traffic with Wireshark and look for patterns such as TCP SYN scans or service probes.
+
+## Steps
+1. Run `nmap -sS <target>` from the attacker machine.
+2. Monitor the network with Wireshark.
+3. Review the packets to identify scan characteristics.


### PR DESCRIPTION
## Summary
- add network monitoring attack scenario documents for Nmap scanning, brute force, and malware beaconing
- link scenarios from network monitoring README and clean up duplicated content

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6891615eda8c83208ff5fd8546fddc73