### PR TITLE
fix: replace invalid CORS wildcard+credentials config with explicit origins

### DIFF
--- a/projects/defensive/monitor_the_situation/backend/app.py
+++ b/projects/defensive/monitor_the_situation/backend/app.py
@@ -45,10 +45,18 @@ def create_app(settings: Settings, db: Database) -> FastAPI:
     from backend.api.websocket import hub
     app.state.ws_hub = hub
 
-    # CORS -- allow everything (homelab)
+    # CORS -- permissive for homelab use.
+    # Note: allow_credentials=True requires explicit origins (not "*").
+    # Default to localhost variants; override via CORS_ORIGINS env var.
+    cors_origins = settings.cors_origins or [
+        "http://localhost:5173",
+        "http://localhost:3000",
+        "http://127.0.0.1:5173",
+        "http://127.0.0.1:3000",
+    ]
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/projects/defensive/monitor_the_situation/backend/config.py
+++ b/projects/defensive/monitor_the_situation/backend/config.py
@@ -23,6 +23,9 @@ class Settings:
     host: str = "0.0.0.0"
     port: int = 8000
 
+    # CORS allowed origins (comma-separated). Leave empty for localhost defaults.
+    cors_origins_str: str = ""
+
     # API keys (all optional -- demo mode used when absent)
     nvd_api_key: str = ""
     greynoise_api_key: str = ""
@@ -87,6 +90,11 @@ class Settings:
             self.abuseipdb_api_key,
             self.otx_api_key,
         ])
+
+    @property
+    def cors_origins(self) -> list[str]:
+        """Parse comma-separated CORS origins, or return empty list for defaults."""
+        return [u.strip() for u in self.cors_origins_str.split(",") if u.strip()]
 
     @property
     def rss_feeds(self) -> list[str]:


### PR DESCRIPTION
allow_origins=["*"] combined with allow_credentials=True is invalid per
the CORS spec — browsers silently ignore the wildcard when credentials
are involved. Replace with explicit localhost origins (5173/3000) that
cover Vite and common dev servers, configurable via MTS_CORS_ORIGINS_STR
env var for other setups.

https://claude.ai/code/session_01Cq36kpxqBLxhiBGjr8iVAz